### PR TITLE
Generate MANIFEST with Gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,17 +9,19 @@ buildscript {
 }
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
     `java-library`
     id("net.minecraftforge.gradle")
     id("net.minecrell.licenser") version "0.4"
 }
 
-defaultTasks("licenseFormat", "build")
-
 apply {
     plugin("org.spongepowered.mixin")
 }
+
+defaultTasks("licenseFormat", "build")
+
+group = "org.spongepowered"
+version = "0.1.0-SNAPSHOT"
 
 minecraft {
     mappings("snapshot", "20200119-1.14.3")
@@ -69,4 +71,22 @@ dependencies {
     implementation("org.spongepowered:configurate-json:3.6.1")
     // Use JUnit test framework
     testImplementation("junit:junit:4.12")
+}
+
+tasks.jar {
+    manifest {
+        attributes(
+                // The basics
+                "Specification-Title" to "SpongePowered Plugin Subsystem",
+                "Specification-Version" to archiveVersion.get(),
+                "Specification-Vendor" to "SpongePowered",
+                "Implementation-Title" to "plugin-spi",
+                "Implementation-Version" to archiveVersion.get(),
+                "Implementation-Vendor" to "SpongePowered",
+
+                // Test Plugin
+                "Loader" to "java_sponge",
+                "MixinConfigs" to "mixins.json"
+        )
+    }
 }

--- a/src/main/java/org/spongepowered/launch/plugin/PluginModule.java
+++ b/src/main/java/org/spongepowered/launch/plugin/PluginModule.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of plugin-spi, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.launch.plugin;
 
 import com.google.inject.AbstractModule;


### PR DESCRIPTION
Unfortunately Gradle won't merge its attributes with the existing
file at runtime, therefore in addition to the current file I have
introduced an additional generation with Gradle including both
standard Java attributes and those required for this environment.

The generated manifest is as so:
```
    Manifest-Version: 1.0
    Implementation-Title: plugin-spi
    MixinConfigs: mixins.json
    Implementation-Version: 0.1.0-SNAPSHOT
    Loader: java_sponge
    Specification-Vendor: SpongePowered
    Specification-Title: SpongePowered Plugin Subsystem
    Specification-Version: 0.1.0-SNAPSHOT
    Implementation-Vendor: SpongePowered
```