### PR TITLE
Remove anti-pattern #of(...) methods

### DIFF
--- a/src/main/java/org/spongepowered/plugin/PluginCandidate.java
+++ b/src/main/java/org/spongepowered/plugin/PluginCandidate.java
@@ -31,13 +31,9 @@ public final class PluginCandidate {
     private final PluginMetadata metadata;
     private final PluginFile pluginFile;
 
-    private PluginCandidate(final PluginMetadata metadata, final PluginFile pluginFile) {
+    public PluginCandidate(final PluginMetadata metadata, final PluginFile pluginFile) {
         this.metadata = metadata;
         this.pluginFile = pluginFile;
-    }
-
-    public static PluginCandidate of(final PluginMetadata metadata, final PluginFile pluginFile) {
-        return new PluginCandidate(metadata, pluginFile);
     }
 
     public PluginMetadata getMetadata() {

--- a/src/main/java/org/spongepowered/plugin/PluginFile.java
+++ b/src/main/java/org/spongepowered/plugin/PluginFile.java
@@ -32,14 +32,10 @@ import javax.annotation.Nullable;
 
 public final class PluginFile {
 
-    public static PluginFile of(final Path rootPath, @Nullable final Manifest manifest) {
-        return new PluginFile(rootPath, manifest);
-    }
-
     private final Path rootPath;
     @Nullable private final Manifest manifest;
 
-    private PluginFile(final Path rootPath, @Nullable final Manifest manifest) {
+    public PluginFile(final Path rootPath, @Nullable final Manifest manifest) {
         this.rootPath = rootPath;
         this.manifest = manifest;
     }

--- a/src/main/java/org/spongepowered/plugin/jvm/JVMPluginLanguageService.java
+++ b/src/main/java/org/spongepowered/plugin/jvm/JVMPluginLanguageService.java
@@ -83,7 +83,7 @@ public abstract class JVMPluginLanguageService implements PluginLanguageService 
                     if (pluginMetadataContainer != null) {
                         for (final Map.Entry<String, PluginMetadata> metadataEntry : pluginMetadataContainer.getAllMetadata().entrySet()) {
                             final PluginMetadata metadata = metadataEntry.getValue();
-                            final PluginCandidate candidate = PluginCandidate.of(metadata, pluginFile);
+                            final PluginCandidate candidate = new PluginCandidate(metadata, pluginFile);
                             pluginCandidates.add(candidate);
                             perStrategyCandidates.add(candidate);
                         }

--- a/src/main/java/org/spongepowered/plugin/jvm/discover/DiscoverStrategies.java
+++ b/src/main/java/org/spongepowered/plugin/jvm/discover/DiscoverStrategies.java
@@ -104,7 +104,7 @@ public enum DiscoverStrategies implements DiscoverStrategy {
                             continue;
                         }
 
-                        pluginFiles.add(PluginFile.of(path, manifest));
+                        pluginFiles.add(new PluginFile(path, manifest));
                     } catch (final IOException e) {
                         environment.getLogger().error("Error reading '{}' as a Jar file when traversing classloader resources for plugin discovery! Skipping...", url, e);
                     }
@@ -139,7 +139,7 @@ public enum DiscoverStrategies implements DiscoverStrategy {
                         continue;
                     }
 
-                    pluginFiles.add(PluginFile.of(path, manifest));
+                    pluginFiles.add(new PluginFile(path, manifest));
                 }
             }
 


### PR DESCRIPTION
I personally consider thin* #of methods on classes to be an
anti-pattern, they don't serve any benefit - running the #of(...)
method is identical to new X(...).

Though its not an issue here, a possible consequence of this pattern
is the inability to extend concepts in derivative software.

\* I define thin to be the lack of any of its own logic - an example
  where I could see an #of(...) method making sense is something like
  Version(int major, int minor) and Version.of(String version), where
  the #of(...) method actually has logic of its own, that doesn't make
  much sense being a constructor and would otherwise exist in a utility
  class - or worse, implemented differently everywhere.