### PR TITLE
Replace guava usage with java methods

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,6 @@ license {
 
 dependencies {
     api("org.spongepowered:plugin-meta:0.6.0-SNAPSHOT")
-    implementation("com.google.guava:guava:21.0")
     implementation("com.google.inject:guice:4.0")
     implementation("org.apache.logging.log4j:log4j-api:2.8.1")
     implementation("org.checkerframework:checker-qual:3.4.1")

--- a/src/main/java/org/spongepowered/plugin/Blackboard.java
+++ b/src/main/java/org/spongepowered/plugin/Blackboard.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.plugin;
 
-import com.google.common.base.Preconditions;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -43,14 +41,14 @@ public final class Blackboard {
 
     @SuppressWarnings("unchecked")
     public <V> V getOrCreate(final Key<V> key, final Supplier<? super V> defaultValue) {
-        Preconditions.checkNotNull(key);
-        Preconditions.checkNotNull(defaultValue);
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(defaultValue);
 
         return key.clazz.cast(this.values.computeIfAbsent((Key<Object>) key, k -> defaultValue.get()));
     }
 
     public <V> Optional<V> get(final Key<V> key) {
-        Preconditions.checkNotNull(key);
+        Objects.requireNonNull(key);
 
         return Optional.ofNullable(key.clazz.cast(this.values.get(key)));
     }

--- a/src/main/java/org/spongepowered/plugin/jvm/JVMPluginContainer.java
+++ b/src/main/java/org/spongepowered/plugin/jvm/JVMPluginContainer.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.plugin.jvm;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.plugin.PluginCandidate;
@@ -36,6 +34,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 public class JVMPluginContainer implements PluginContainer {
 
@@ -79,7 +78,7 @@ public class JVMPluginContainer implements PluginContainer {
             throw new RuntimeException(String.format("Attempt made to set the plugin within container '%s' twice!",
                 this.candidate.getMetadata().getId()));
         }
-        Preconditions.checkNotNull(instance);
+        Objects.requireNonNull(instance);
         this.instance = instance;
     }
 
@@ -110,9 +109,9 @@ public class JVMPluginContainer implements PluginContainer {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .addValue(this.candidate.getMetadata())
-                .add("file", this.candidate.getFile())
+        return new StringJoiner(", ", JVMPluginContainer.class.getSimpleName() + "[", "]")
+                .add(this.candidate.getMetadata().toString())
+                .add("file=" + this.candidate.getFile())
                 .toString();
     }
 }

--- a/src/main/java/org/spongepowered/plugin/jvm/JVMPluginLanguageService.java
+++ b/src/main/java/org/spongepowered/plugin/jvm/JVMPluginLanguageService.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.plugin.jvm;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.plugin.InvalidPluginException;
 import org.spongepowered.plugin.PluginCandidate;
 import org.spongepowered.plugin.PluginEnvironment;
@@ -46,6 +45,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -114,9 +114,9 @@ public abstract class JVMPluginLanguageService<P extends JVMPluginContainer> imp
 
     @Override
     public void loadPlugin(final PluginEnvironment environment, final P container, final ClassLoader targetClassLoader) throws InvalidPluginException {
-        Preconditions.checkNotNull(environment);
-        Preconditions.checkNotNull(container);
-        Preconditions.checkNotNull(targetClassLoader);
+        Objects.requireNonNull(environment);
+        Objects.requireNonNull(container);
+        Objects.requireNonNull(targetClassLoader);
 
         container.setInstance(this.createPluginInstance(environment, container, targetClassLoader));
     }


### PR DESCRIPTION
Simple PR to apply "requirenonnnul needs to be used as much as possible" policy (mentioned on discord dontknowhomany days ago).

The PR is replacing guava's checknotnull with java's requirenonnul (except for one moreobject -> stringjoiner).

Note: guava is now unused but I've not removed the dependency. Pinging @Zidane for input on what to do.

