### PR TITLE
fix bad jar file names displaying in debug log

### DIFF
--- a/src/main/java/org/spongepowered/plugin/jvm/locator/DirectoryPluginResourceLocatorService.java
+++ b/src/main/java/org/spongepowered/plugin/jvm/locator/DirectoryPluginResourceLocatorService.java
@@ -67,13 +67,13 @@ public final class DirectoryPluginResourceLocatorService extends JVMPluginResour
                         final Manifest manifest = jf.getManifest();
 
                         if (!this.isValidManifest(environment, manifest)) {
-                            environment.getLogger().error("Manifest specified in '{}' is not valid for locator '{}'. Skipping...", jf, this.getName());
+                            environment.getLogger().error("Manifest specified in '{}' is not valid for locator '{}'. Skipping...", path, this.getName());
                             continue;
                         }
 
                         final JarEntry pluginMetadataJarEntry = jf.getJarEntry(this.getMetadataPath());
                         if (pluginMetadataJarEntry == null) {
-                            environment.getLogger().debug("'{}' does not contain any plugin metadata so it is not a plugin. Skipping...", jf);
+                            environment.getLogger().debug("'{}' does not contain any plugin metadata so it is not a plugin. Skipping...", path);
                             continue;
                         }
 


### PR DESCRIPTION
Currently, if a user places an legacy plugin or some other bad jar files, it will show something like `java.util.jar.JarFile@35390ee3` instead of file name in debug logs.
```
[17:12:33] [main/INFO] [Plugin/]: Locating 'java_directory' resources...
[17:12:33] [main/DEBUG] [Plugin/]: 'java.util.jar.JarFile@35390ee3' does not contain any plugin metadata so it is not a plugin. Skipping...
[17:12:33] [main/DEBUG] [Plugin/]: 'java.util.jar.JarFile@5ee2b6f9' does not contain any plugin metadata so it is not a plugin. Skipping...
[17:12:33] [main/DEBUG] [Plugin/]: 'java.util.jar.JarFile@58fb7731' does not contain any plugin metadata so it is not a plugin. Skipping...
[17:12:33] [main/INFO] [Plugin/]: Located [0] resource(s) for 'java_directory'...
```