### PR TITLE
Use URIs instead of URLs.

### DIFF
--- a/src/main/java/org/spongepowered/plugin/PluginContainer.java
+++ b/src/main/java/org/spongepowered/plugin/PluginContainer.java
@@ -29,7 +29,7 @@ import org.spongepowered.plugin.metadata.PluginMetadata;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 import java.util.Optional;
 
 /**
@@ -64,24 +64,24 @@ public interface PluginContainer {
     Object instance();
 
     /**
-     * Resolves the location of a bundled resource, given a relative {@link URL}.
+     * Resolves the location of a bundled resource, given a relative {@link URI}.
      *
-     * @param relative The relative URL
+     * @param relative The relative URI
      * @return The resolved resource location, if available
      */
-    Optional<URL> locateResource(final URL relative);
+    Optional<URI> locateResource(final URI relative);
 
     /**
-     * Opens an {@link InputStream} of the location of a bundled resource, given a relative {@link URL}.
+     * Opens an {@link InputStream} of the location of a bundled resource, given a relative {@link URI}.
      *
-     * @param relative The relative URL
+     * @param relative The relative URI
      * @return The opened resource, if available
      */
-    default Optional<InputStream> openResource(final URL relative) {
+    default Optional<InputStream> openResource(final URI relative) {
         return this.locateResource(relative).flatMap(url -> {
             try {
-                return Optional.of(url.openStream());
-            } catch (IOException e) {
+                return Optional.of(url.toURL().openStream());
+            } catch (final IOException ignored) {
                 return Optional.empty();
             }
         });

--- a/src/main/java/org/spongepowered/plugin/jvm/JVMPluginContainer.java
+++ b/src/main/java/org/spongepowered/plugin/jvm/JVMPluginContainer.java
@@ -31,6 +31,8 @@ import org.spongepowered.plugin.PluginContainer;
 import org.spongepowered.plugin.jvm.locator.JVMPluginResource;
 import org.spongepowered.plugin.metadata.PluginMetadata;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Objects;
 import java.util.Optional;
@@ -69,16 +71,23 @@ public class JVMPluginContainer implements PluginContainer {
     protected void initializeInstance(final Object instance) {
         if (this.instance != null) {
             throw new RuntimeException(String.format("Attempt made to set the plugin within container '%s' twice!",
-                this.candidate.metadata().id()));
+                    this.candidate.metadata().id()));
         }
         this.instance = Objects.requireNonNull(instance);
     }
 
     @Override
-    public Optional<URL> locateResource(final URL relative) {
+    public Optional<URI> locateResource(final URI relative) {
         final ClassLoader classLoader = this.instance().getClass().getClassLoader();
         final URL resolved = classLoader.getResource(relative.getPath());
-        return Optional.ofNullable(resolved);
+        try {
+            if (resolved == null) {
+                return Optional.empty();
+            }
+            return Optional.of(resolved.toURI());
+        } catch (final URISyntaxException ignored) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/src/main/java/org/spongepowered/plugin/jvm/JVMPluginContainer.java
+++ b/src/main/java/org/spongepowered/plugin/jvm/JVMPluginContainer.java
@@ -71,7 +71,7 @@ public class JVMPluginContainer implements PluginContainer {
     protected void initializeInstance(final Object instance) {
         if (this.instance != null) {
             throw new RuntimeException(String.format("Attempt made to set the plugin within container '%s' twice!",
-                    this.candidate.metadata().id()));
+                this.candidate.metadata().id()));
         }
         this.instance = Objects.requireNonNull(instance);
     }


### PR DESCRIPTION
This is a breaking change.

Initially, I had written the resource loading stuff using `URL`s, but hindsight makes it seem like `URI`s are the better approach. Given all RFC 2396 compliant URLs are representable as URIs, this shouldn't be an issue for nearly every case. What this does give us though, is access to `URN`s. Other potential platforms or plugin services might find these useful for finding their resources. There is also a slight usage improvement, where `URI.create(String)` replaces `new URL(String)`'s checked exception with an unchecked one.

I have yet to look at what changes we'll need in Sponge to support this change.